### PR TITLE
Fix PHP 8.4 deprecations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,9 @@
         }
     },
     "require": {
-        "php": ">=5.3.3"
+        "php": ">=7.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.0|^6.0|^7.0|^8.0"
+        "phpunit/phpunit": "^6.0|^7.0|^8.0"
     }
 }

--- a/src/RR/Shunt/Parser.php
+++ b/src/RR/Shunt/Parser.php
@@ -605,7 +605,7 @@ class Parser
         return 0;
     }
 
-    public static function parse($term, Context $ctx = null)
+    public static function parse($term, ?Context $ctx = null)
     {
         $obj = new self(new Scanner($term));
 


### PR DESCRIPTION
```
RR\Shunt\Parser::parse(): Implicitly marking parameter $ctx as nullable is deprecated, the explicit nullable type must be used instead
```

I had to bump PHP requirement because it's not compatible with old PHP versions